### PR TITLE
Derive clone for MidiMessage

### DIFF
--- a/src/midi.rs
+++ b/src/midi.rs
@@ -1,7 +1,7 @@
 //! This module contains data types to represent the different messages that can be sent over MIDI.
 
 /// An enum with variants for all possible Midi messages.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum MidiMessage {
     // Channel voice messages
     /// Note Off message


### PR DESCRIPTION
I think it's reasonable to do this?  Looking around it seems like there could even be an argument for deriving Copy, but at least with Clone you have to manually call it and that seems harmless.  I'm still pretty new at both rust and embedded stuff in general though, so...