### PR TITLE
use debug-assert for clamping values

### DIFF
--- a/src/midi.rs
+++ b/src/midi.rs
@@ -181,7 +181,7 @@ pub struct Program(u8);
 
 impl From<u8> for Program {
     fn from(value: u8) -> Self {
-        assert!(value <= 127);
+        debug_assert!(value <= 127);
         Program(value)
     }
 }


### PR DESCRIPTION
This is a small change I'd like to suggest
I think these clamps are most useful when debugging or running tests. In most situations this code will never be called with out-of-bounds data unless there is an error in our parsing code. So we want this code to panic! in tests or when debugging. But we probably don't want this extra check in production code. Especially on an embedded platform a panic in production code leaves the embedded device inoperable.