### PR TITLE
add const new functions to the various midi types

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -145,7 +145,8 @@ impl Channel {
 
 impl From<u8> for Channel {
     fn from(channel: u8) -> Self {
-        Channel(channel.min(15))
+        debug_assert!(channel <= 15);
+        Self::new(channel)
     }
 }
 
@@ -176,7 +177,8 @@ impl Control {
 
 impl From<u8> for Control {
     fn from(control: u8) -> Self {
-        Control(control.min(127))
+        debug_assert!(control <= 127);
+        Self::new(control)
     }
 }
 
@@ -207,7 +209,7 @@ impl Program {
 
 impl From<u8> for Program {
     fn from(value: u8) -> Self {
-        assert!(value <= 127);
+        debug_assert!(value <= 127);
         Program(value)
     }
 }
@@ -239,7 +241,8 @@ impl Value7 {
 
 impl From<u8> for Value7 {
     fn from(value: u8) -> Self {
-        Value7(value.min(127))
+        debug_assert!(value <= 127);
+        Self::new(value)
     }
 }
 
@@ -279,7 +282,9 @@ impl Value14 {
 
 impl From<(u8, u8)> for Value14 {
     fn from(value: (u8, u8)) -> Self {
-        Value14(value.0.min(127), value.1.min(127))
+        debug_assert!(value.0 <= 127);
+        debug_assert!(value.1 <= 127);
+        Self(value.0.min(127), value.1.min(127))
     }
 }
 
@@ -291,7 +296,7 @@ impl From<Value14> for (u8, u8) {
 
 impl From<u16> for Value14 {
     fn from(value: u16) -> Self {
-        Value14(((value & 0x3f80) >> 7) as u8, (value & 0x007f) as u8)
+        Self(((value & 0x3f80) >> 7) as u8, (value & 0x007f) as u8)
     }
 }
 
@@ -419,7 +424,8 @@ impl QuarterFrame {
 
 impl From<u8> for QuarterFrame {
     fn from(value: u8) -> Self {
-        Self(value.min(127))
+        debug_assert!(value <= 127);
+        Self::new(value)
     }
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -268,14 +268,13 @@ impl Value14 {
     /// * The `val` will be clamped so it is in the 0..127 valid range
     ///
     pub const fn new(val: i16) -> Self {
-        let value = if val <= -8192i16 {
+        let value = (if val <= -8192i16 {
             -8192i16
         } else if val >= 8191i16 {
             8191i16
         } else {
             val
-        }
-        .saturating_add(8192i16) as u16;
+        } + 8192i16) as u16;
         Value14(((value & 0x3f80) >> 7) as u8, (value & 0x007f) as u8)
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -265,9 +265,9 @@ impl Value14 {
     /// * The `val` will be clamped so it is in the 0..127 valid range
     ///
     pub const fn new(val: i16) -> Self {
-        let value = if val < -8192i16 {
+        let value = if val <= -8192i16 {
             -8192i16
-        } else if val > 8191i16 {
+        } else if val >= 8191i16 {
             8191i16
         } else {
             val
@@ -386,6 +386,20 @@ pub enum QuarterFrameType {
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct QuarterFrame(u8);
+
+impl QuarterFrame {
+    /// Create a new `QuarterFrame`
+    ///
+    /// # Arguments
+    /// * `val` - the value
+    ///
+    /// # Note
+    /// * The `val` will be clamped so it is in the 0..127 valid range
+    ///
+    pub const fn new(val: u8) -> Self {
+        Self(if val > 127 { 127 } else { val })
+    }
+}
 
 /*
 impl QuarterFrame {

--- a/src/note.rs
+++ b/src/note.rs
@@ -6,6 +6,20 @@
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Note(u8);
 
+impl Note {
+    /// Create a new `Note`
+    ///
+    /// # Arguments
+    /// * `val` - the note number value
+    ///
+    /// # Note
+    /// * The `val` will be clamped so it is in the 0..127 valid range
+    ///
+    pub const fn new(val: u8) -> Self {
+        Self(if val > 127 { 127 } else { val })
+    }
+}
+
 impl From<u8> for Note {
     fn from(note: u8) -> Self {
         Note(note.min(127))

--- a/src/note.rs
+++ b/src/note.rs
@@ -22,7 +22,8 @@ impl Note {
 
 impl From<u8> for Note {
     fn from(note: u8) -> Self {
-        Note(note.min(127))
+        debug_assert!(note <= 127);
+        Self::from(note)
     }
 }
 


### PR DESCRIPTION
`const` new can be pretty useful..

`const CHAN1: Channel = Channel::new(0);`

and could also allow us to define the note numbers as requested earlier..

`const G0: Note = Note::new(19);`